### PR TITLE
fix:보이스채널ID null 에러 해결

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,8 +50,8 @@ function deleteChannelMessage(voiceChannel){
 }
 
 async function processQueue() {
-	const voiceChannelId = currentConnection.joinConfig.channelId;
 	if (isPlaying || messageQueue.length === 0) return;
+	const voiceChannelId = currentConnection.joinConfig.channelId;
 
 	const {message, text} = messageQueue.shift();
 	isPlaying = true;


### PR DESCRIPTION
- [x] 빈 채널이 되었을때, queue 가 Null 이 되는 이슈해결.